### PR TITLE
Add bank seller plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bankseller/BankSellerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bankseller/BankSellerConfig.java
@@ -1,0 +1,16 @@
+package net.runelite.client.plugins.microbot.bankseller;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup("BankSeller")
+public interface BankSellerConfig extends Config {
+    @ConfigItem(
+            keyName = "blacklist",
+            name = "Blacklist",
+            description = "Comma separated list of items not to sell",
+            position = 0
+    )
+    default String blacklist() { return ""; }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bankseller/BankSellerOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bankseller/BankSellerOverlay.java
@@ -1,0 +1,46 @@
+package net.runelite.client.plugins.microbot.bankseller;
+
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.util.misc.TimeUtils;
+import net.runelite.client.ui.overlay.OverlayPanel;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.components.LineComponent;
+import net.runelite.client.ui.overlay.components.TitleComponent;
+
+import javax.inject.Inject;
+import java.awt.*;
+import java.time.Instant;
+
+public class BankSellerOverlay extends OverlayPanel {
+    private final BankSellerPlugin plugin;
+
+    @Inject
+    BankSellerOverlay(BankSellerPlugin plugin) {
+        super(plugin);
+        this.plugin = plugin;
+        setPosition(OverlayPosition.TOP_LEFT);
+        setNaughty();
+    }
+
+    @Override
+    public Dimension render(Graphics2D graphics) {
+        panelComponent.setPreferredSize(new Dimension(200, 100));
+        panelComponent.getChildren().add(TitleComponent.builder()
+                .text("Bank Seller v" + BankSellerPlugin.VERSION)
+                .color(Color.GREEN)
+                .build());
+        panelComponent.getChildren().add(LineComponent.builder()
+                .left("Items Sold:")
+                .right(Integer.toString(plugin.getItemsSold()))
+                .build());
+        panelComponent.getChildren().add(LineComponent.builder()
+                .left("Time running:")
+                .right(TimeUtils.getFormattedDurationBetween(plugin.getStartTime(), Instant.now()))
+                .build());
+        panelComponent.getChildren().add(LineComponent.builder()
+                .left("Status:")
+                .right(Microbot.status)
+                .build());
+        return super.render(graphics);
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bankseller/BankSellerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bankseller/BankSellerPlugin.java
@@ -1,0 +1,54 @@
+package net.runelite.client.plugins.microbot.bankseller;
+
+import com.google.inject.Provides;
+import lombok.Getter;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.ui.overlay.OverlayManager;
+
+import javax.inject.Inject;
+import java.awt.*;
+import java.time.Instant;
+
+@PluginDescriptor(
+        name = PluginDescriptor.Default + "Bank Seller",
+        description = "Sells bank items using the Grand Exchange",
+        tags = {"bank", "seller", "ge", "microbot"},
+        enabledByDefault = false
+)
+public class BankSellerPlugin extends Plugin {
+    static final String VERSION = "1.0";
+
+    @Inject
+    private OverlayManager overlayManager;
+    @Inject
+    private BankSellerOverlay overlay;
+    @Inject
+    private BankSellerConfig config;
+    @Inject
+    private BankSellerScript script;
+
+    @Getter
+    private Instant startTime;
+
+    @Provides
+    BankSellerConfig provideConfig(ConfigManager configManager) {
+        return configManager.getConfig(BankSellerConfig.class);
+    }
+
+    @Override
+    protected void startUp() throws AWTException {
+        startTime = Instant.now();
+        overlayManager.add(overlay);
+        script.run(this, config);
+    }
+
+    @Override
+    protected void shutDown() {
+        script.shutdown();
+        overlayManager.remove(overlay);
+    }
+
+    int getItemsSold() { return script.getItemsSold(); }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bankseller/BankSellerScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bankseller/BankSellerScript.java
@@ -1,0 +1,99 @@
+package net.runelite.client.plugins.microbot.bankseller;
+
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.Script;
+import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
+import net.runelite.client.plugins.microbot.util.grandexchange.Rs2GrandExchange;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2ItemModel;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static net.runelite.client.plugins.microbot.util.Global.sleep;
+import static net.runelite.client.plugins.microbot.util.Global.sleepUntil;
+
+public class BankSellerScript extends Script {
+    private BankSellerPlugin plugin;
+    private BankSellerConfig config;
+    private final Set<String> blacklist = new HashSet<>();
+    private int itemsSold = 0;
+
+    int getItemsSold() { return itemsSold; }
+
+    public boolean run(BankSellerPlugin plugin, BankSellerConfig config) {
+        this.plugin = plugin;
+        this.config = config;
+        if (!config.blacklist().isBlank()) {
+            Arrays.stream(config.blacklist().split(","))
+                    .map(String::trim)
+                    .filter(s -> !s.isEmpty())
+                    .forEach(blacklist::add);
+        }
+
+        mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
+            try {
+                if (!Microbot.isLoggedIn() || !super.run()) return;
+
+                if (Rs2Inventory.isEmpty()) {
+                    handleBank();
+                    return;
+                }
+
+                handleSelling();
+            } catch (Exception ex) {
+                Microbot.logStackTrace(this.getClass().getSimpleName(), ex);
+            }
+        }, 0, 600, TimeUnit.MILLISECONDS);
+        return true;
+    }
+
+    private void handleBank() {
+        if (!Rs2Bank.isOpen()) {
+            Rs2Bank.useBank();
+            sleepUntil(Rs2Bank::isOpen);
+            return;
+        }
+
+        for (Rs2ItemModel item : Rs2Bank.bankItems()) {
+            if (!item.isTradeable()) continue;
+            String name = item.getName();
+            if (name.equalsIgnoreCase("Coins")) continue;
+            if (blacklist.stream().anyMatch(b -> b.equalsIgnoreCase(name))) continue;
+            if (Rs2Bank.withdrawAll(name)) {
+                sleepUntil(() -> Rs2Inventory.hasItem(name));
+                break;
+            }
+        }
+        Rs2Bank.closeBank();
+    }
+
+    private void handleSelling() {
+        if (!Rs2GrandExchange.isOpen()) {
+            Rs2GrandExchange.openExchange();
+            sleepUntil(Rs2GrandExchange::isOpen);
+            return;
+        }
+
+        if (Rs2GrandExchange.getAvailableSlot() == null && Rs2GrandExchange.hasSoldOffer()) {
+            Rs2GrandExchange.collectAllToBank();
+            sleepUntil(() -> Rs2GrandExchange.getAvailableSlot() != null);
+        }
+
+        Rs2Inventory.items().forEachOrdered(item -> {
+            if (!item.isTradeable()) return;
+            String name = item.getName();
+            if (name.equalsIgnoreCase("Coins")) return;
+            if (blacklist.stream().anyMatch(b -> b.equalsIgnoreCase(name))) return;
+            int price = Rs2GrandExchange.getPrice(item.getId());
+            if (price <= 0) price = 1;
+            int sellPrice = (int)(price * 0.85); // low price for quick sale
+            Rs2GrandExchange.sellItem(name, item.getQuantity(), sellPrice);
+            itemsSold += item.getQuantity();
+            sleepUntil(() -> !Rs2GrandExchange.isOfferScreenOpen());
+            sleep(300, 600);
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- add a new Bank Seller plugin that sells bank items using the GE
- allow blacklisting items from being sold
- sell items at a low price for fast sales
- display plugin name, items sold and runtime in overlay
- wait conditionally during GE and bank actions

## Testing
- `mvn -q -DskipTests install` *(fails: Non-resolvable import POM: com.google.inject:guice-bom:pom:4.1.0)*

------
https://chatgpt.com/codex/tasks/task_e_688413abb5fc8330ba8cdfe4ada5a00a