### PR TITLE
Update BankSeller inventory management

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bankseller/BankSellerScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bankseller/BankSellerScript.java
@@ -57,14 +57,22 @@ public class BankSellerScript extends Script {
             return;
         }
 
+        if (!Rs2Inventory.isEmpty()) {
+            Rs2Bank.depositAll();
+            sleepUntil(Rs2Inventory::isEmpty);
+            return;
+        }
+
+        Rs2Bank.setWithdrawAsNote();
+
         for (Rs2ItemModel item : Rs2Bank.bankItems()) {
+            if (Rs2Inventory.isFull()) break;
             if (!item.isTradeable()) continue;
             String name = item.getName();
             if (name.equalsIgnoreCase("Coins")) continue;
             if (blacklist.stream().anyMatch(b -> b.equalsIgnoreCase(name))) continue;
             if (Rs2Bank.withdrawAll(name)) {
                 sleepUntil(() -> Rs2Inventory.hasItem(name));
-                break;
             }
         }
         Rs2Bank.closeBank();


### PR DESCRIPTION
## Summary
- bank handles inventory cleanup before withdrawing items
- withdraws multiple item types until the inventory is full

## Testing
- `mvn -q -pl runelite-client -am package -DskipTests` *(fails: Non-resolvable import POM)*

------
https://chatgpt.com/codex/tasks/task_e_6884343dd7548330948195af229ea8d3