### PR TITLE
Update BankSeller stopping logic

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bankseller/BankSellerScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bankseller/BankSellerScript.java
@@ -56,10 +56,9 @@ public class BankSellerScript extends Script {
         if (!Rs2Bank.isOpen()) {
             Rs2Bank.useBank();
             sleepUntil(Rs2Bank::isOpen);
-        }
-
-        if (!Rs2Bank.isOpen()) {
-            return false;
+            if (!Rs2Bank.isOpen()) {
+                return true; // keep script running until bank is reachable
+            }
         }
 
         if (!Rs2Inventory.isEmpty()) {
@@ -72,8 +71,8 @@ public class BankSellerScript extends Script {
         boolean withdrew = false;
 
         while (!Rs2Inventory.isFull()) {
-            Rs2ItemModel nextItem = Rs2Bank.bankItems()
-                    .filter(item -> item.isTradeable())
+            Rs2ItemModel nextItem = Rs2Bank.bankItems().stream()
+                    .filter(Rs2ItemModel::isTradeable)
                     .filter(item -> !item.getName().equalsIgnoreCase("Coins"))
                     .filter(item -> blacklist.stream().noneMatch(b -> b.equalsIgnoreCase(item.getName())))
                     .findFirst()
@@ -92,8 +91,13 @@ public class BankSellerScript extends Script {
             }
         }
 
+        boolean hasMore = Rs2Bank.bankItems().stream()
+                .anyMatch(item -> item.isTradeable()
+                        && !item.getName().equalsIgnoreCase("Coins")
+                        && blacklist.stream().noneMatch(b -> b.equalsIgnoreCase(item.getName())));
+
         Rs2Bank.closeBank();
-        return withdrew;
+        return withdrew || hasMore;
     }
 
     private void handleSelling() {
@@ -114,10 +118,12 @@ public class BankSellerScript extends Script {
                 String name = item.getName();
                 if (name.equalsIgnoreCase("Coins")) return;
                 if (blacklist.stream().anyMatch(b -> b.equalsIgnoreCase(name))) return;
+
                 int price = Rs2GrandExchange.getPrice(item.getId());
                 if (price <= 0) price = 1;
-                int sellPrice = (int)(price * 0.85); // low price for quick sale
+                int sellPrice = (int) (price * 0.85); // low price for quick sale
                 Rs2GrandExchange.sellItem(name, item.getQuantity(), sellPrice);
+
                 itemsSold += item.getQuantity();
                 sleepUntil(() -> !Rs2GrandExchange.isOfferScreenOpen());
                 sleep(300, 600);


### PR DESCRIPTION
## Summary
- keep trying to open the bank before stopping
- stop plugin only once no tradeable items remain in bank or inventory

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable import POM: com.google.inject:guice-bom)*

------
https://chatgpt.com/codex/tasks/task_e_688441db31e48330892ebb268fb27267