### PR TITLE
Update BankSeller stopping logic

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bankseller/BankSellerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bankseller/BankSellerConfig.java
@@ -3,6 +3,7 @@ package net.runelite.client.plugins.microbot.bankseller;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.Range;
 
 @ConfigGroup("BankSeller")
 public interface BankSellerConfig extends Config {
@@ -13,4 +14,13 @@ public interface BankSellerConfig extends Config {
             position = 0
     )
     default String blacklist() { return ""; }
+
+    @ConfigItem(
+            keyName = "actionDelay",
+            name = "Action Delay",
+            description = "Base delay in ms between withdrawing and selling",
+            position = 1
+    )
+    @Range(min = 100, max = 2000)
+    default int actionDelay() { return 500; }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bankseller/BankSellerScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bankseller/BankSellerScript.java
@@ -3,6 +3,8 @@ package net.runelite.client.plugins.microbot.bankseller;
 import net.runelite.client.plugins.microbot.Microbot;
 import net.runelite.client.plugins.microbot.Script;
 import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
+import net.runelite.client.plugins.microbot.util.grandexchange.GrandExchangeAction;
+import net.runelite.client.plugins.microbot.util.grandexchange.GrandExchangeRequest;
 import net.runelite.client.plugins.microbot.util.grandexchange.Rs2GrandExchange;
 import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
 import net.runelite.client.plugins.microbot.util.inventory.Rs2ItemModel;
@@ -53,13 +55,17 @@ public class BankSellerScript extends Script {
     }
 
     private boolean handleBank() {
-        if (!Rs2Bank.isOpen()) {
-            Rs2Bank.useBank();
-            sleepUntil(Rs2Bank::isOpen);
+        if (Rs2GrandExchange.isOpen()) {
+            Rs2GrandExchange.closeExchange();
+            sleepUntil(() -> !Rs2GrandExchange.isOpen());
         }
 
         if (!Rs2Bank.isOpen()) {
-            return false;
+            Rs2Bank.useBank();
+            sleepUntil(Rs2Bank::isOpen);
+            if (!Rs2Bank.isOpen()) {
+                return true; // keep script running until bank is reachable
+            }
         }
 
         if (!Rs2Inventory.isEmpty()) {
@@ -72,28 +78,34 @@ public class BankSellerScript extends Script {
         boolean withdrew = false;
 
         while (!Rs2Inventory.isFull()) {
-            Rs2ItemModel nextItem = Rs2Bank.bankItems()
-                    .filter(item -> item.isTradeable())
+            Rs2ItemModel bankItem = Rs2Bank.bankItems().stream()
+                    .filter(Rs2ItemModel::isTradeable)
                     .filter(item -> !item.getName().equalsIgnoreCase("Coins"))
                     .filter(item -> blacklist.stream().noneMatch(b -> b.equalsIgnoreCase(item.getName())))
                     .findFirst()
                     .orElse(null);
 
-            if (nextItem == null) {
+            if (bankItem == null) {
                 break;
             }
 
-            String name = nextItem.getName();
-            if (Rs2Bank.withdrawAll(name)) {
+            String bankItemName = bankItem.getName();
+            if (Rs2Bank.withdrawAll(bankItemName)) {
                 withdrew = true;
-                sleepUntil(() -> Rs2Inventory.hasItem(name));
+                sleepUntil(() -> Rs2Inventory.hasItem(bankItemName));
+                sleep(config.actionDelay(), config.actionDelay() + 200);
             } else {
                 break;
             }
         }
 
+        boolean hasMore = Rs2Bank.bankItems().stream()
+                .anyMatch(item -> item.isTradeable()
+                        && !item.getName().equalsIgnoreCase("Coins")
+                        && blacklist.stream().noneMatch(b -> b.equalsIgnoreCase(item.getName())));
+
         Rs2Bank.closeBank();
-        return withdrew;
+        return withdrew || hasMore;
     }
 
     private void handleSelling() {
@@ -104,24 +116,50 @@ public class BankSellerScript extends Script {
                 continue;
             }
 
-            if (Rs2GrandExchange.getAvailableSlot() == null && Rs2GrandExchange.hasSoldOffer()) {
-                Rs2GrandExchange.collectAllToBank();
-                sleepUntil(() -> Rs2GrandExchange.getAvailableSlot() != null);
+            if (Rs2GrandExchange.getAvailableSlot() == null) {
+                if (Rs2GrandExchange.hasSoldOffer()) {
+                    Rs2GrandExchange.collectAllToBank();
+                    sleepUntil(() -> Rs2GrandExchange.getAvailableSlot() != null);
+                } else {
+                    sleep(600, 1200);
+                    continue;
+                }
             }
 
-            Rs2Inventory.items().forEachOrdered(item -> {
-                if (!item.isTradeable()) return;
-                String name = item.getName();
-                if (name.equalsIgnoreCase("Coins")) return;
-                if (blacklist.stream().anyMatch(b -> b.equalsIgnoreCase(name))) return;
-                int price = Rs2GrandExchange.getPrice(item.getId());
-                if (price <= 0) price = 1;
-                int sellPrice = (int)(price * 0.85); // low price for quick sale
-                Rs2GrandExchange.sellItem(name, item.getQuantity(), sellPrice);
-                itemsSold += item.getQuantity();
+            for (Rs2ItemModel itemToSell : Rs2Inventory.all()) {
+                if (!itemToSell.isTradeable()) {
+                    continue;
+                }
+
+                String itemName = itemToSell.getName();
+                if (itemName.equalsIgnoreCase("Coins")) {
+                    continue;
+                }
+
+                if (blacklist.stream().anyMatch(b -> b.equalsIgnoreCase(itemName))) {
+                    continue;
+                }
+
+                int itemPrice = Rs2GrandExchange.getPrice(itemToSell.getId());
+                if (itemPrice <= 0) {
+                    itemPrice = 1;
+                }
+
+                int offerPrice = (int) (itemPrice * 0.85);
+
+                GrandExchangeRequest request = GrandExchangeRequest.builder()
+                        .action(GrandExchangeAction.SELL)
+                        .itemName(itemName)
+                        .quantity(itemToSell.getQuantity())
+                        .price(offerPrice)
+                        .build();
+
+                Rs2GrandExchange.processOffer(request);
+
+                itemsSold += itemToSell.getQuantity();
                 sleepUntil(() -> !Rs2GrandExchange.isOfferScreenOpen());
-                sleep(300, 600);
-            });
+                sleep(config.actionDelay(), config.actionDelay() + 300);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- keep trying to open the bank before stopping
- stop plugin only once no tradeable items remain in bank or inventory
- adjust selling loop for new Grand Exchange API
- fix variable reuse in the selling loop
- add slider to configure delay between withdraw and sell actions
- close Grand Exchange before opening bank
- rename inner loop variable to avoid redeclaration
- resolve duplicate variable warnings in BankSellerScript

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable import POM: com.google.inject:guice-bom)*

------
https://chatgpt.com/codex/tasks/task_e_688441db31e48330892ebb268fb27267